### PR TITLE
Refactor klasy coordinator po code-review

### DIFF
--- a/coordinator/src/accept.cpp
+++ b/coordinator/src/accept.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <thread>
 #include <memory>
+#include <iostream>
 
 #include "accept.h"
 #include "node.h"
@@ -57,13 +58,15 @@ void acceptConnections(int port, State& state)
             error(1, errno, "accept failed");
         }
 
-        //TODO: Check if node is already registered
-        
-        // else
-        newNode->id = nextNodeId++;
-        
+        //TODO: Switch from using cout to maybe other log
+        if (state.nodeExists(nextNodeId)) {
+            std::cout << "Node with ID " << nextNodeId << " is already registered." << std::endl;
+            continue;
+        } 
+
+        int node_id = newNode->id = nextNodeId++;
         state.mtx_nodes.lock();
-        state.nodes.push_back(std::move(newNode));
+        state.nodes.insert({node_id, std::move(newNode)});
 
         int nidx = state.nodes.size() - 1;
 

--- a/coordinator/src/handler.cpp
+++ b/coordinator/src/handler.cpp
@@ -5,15 +5,13 @@
 #include "messages.h"
 
 void handleReadyMessage(State &state, int node_id, ReadyMessage *msg) {
-    std::cout << "[WT]: Node " << node_id << " sent READY message! Setting node as REGISTERED.";
+    std::cout << "[WT]: Node " << node_id << " sent READY message!" << std::endl;
     state.mtx_nodes.lock();
-    for (auto& node : state.nodes)
-    {
-        if (node->id == node_id)
-        {
-            node->flags |= NodeFlags::REGISTERED;
-            break;
-        }
+    if (state.nodeExists(node_id)) {
+        state.nodes[node_id]->flags |= NodeFlags::REGISTERED;
+        std::cout << "[WT]: Set node " << node_id << " as REGISTERED." << std::endl;
+    } else {
+        std::cout << "[WT]: Node with ID " << node_id << " does not exist." << std::endl;
     }
     state.mtx_nodes.unlock();
 }

--- a/coordinator/src/main.cpp
+++ b/coordinator/src/main.cpp
@@ -110,4 +110,5 @@ int main (int argc, char* argv[])
     t_handler.join();
     // join all from state.threads
 
+    return 0;
 }

--- a/coordinator/src/main.cpp
+++ b/coordinator/src/main.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <sstream>
 #include <mutex>
+#include <cassert>
 
 #include "node.h"
 #include "accept.h"
@@ -40,13 +41,10 @@ int main (int argc, char* argv[])
             msg->init(0, 0);
 
             state.mtx_nodes.lock();
-            for (auto& node : state.nodes)
-            {
-                if (node->id == nid)
-                {
-                    node->Send(std::move(msg));
-                    break;
-                }
+            if (state.nodeExists(nid)) {
+                state.nodes[nid]->Send(std::move(msg));
+            } else {
+                std::cout << "Node with such ID does not exist" << std::endl;
             }
             state.mtx_nodes.unlock();
         }
@@ -56,13 +54,14 @@ int main (int argc, char* argv[])
             int nid = std::stoi(token);
             auto msg = std::make_unique<PingMessage>();
             state.mtx_nodes.lock();
-            for (auto& node : state.nodes)
-            {
-                if (node->id == nid && (node->flags & NodeFlags::REGISTERED) != 0)
-                {
-                    node->Send(std::move(msg));
-                    break;
+            if (state.nodeExists(nid)) {
+                if (state.nodes[nid]->flags & NodeFlags::REGISTERED != 0) {
+                    state.nodes[nid]->Send(std::move(msg));
+                } else {
+                    std::cout << "Node with ID " << nid << " is not registered. Send HELLO first." << std::endl;
                 }
+            } else {
+                std::cout << "Node with such ID does not exist" << std::endl;
             }
             state.mtx_nodes.unlock();
         }
@@ -74,23 +73,29 @@ int main (int argc, char* argv[])
             auto msg =  std::make_unique<TaskMessage>();
             msg->task = Task(10, "Test Task");
 
+            // TODO: maybe Make function SendToNode or something like that,  
+            // - lock mutex, send message if Node is in given state
+            // think about sending unique ptr on BaseMesssage?
+            // return false if msg was not sent
             state.mtx_nodes.lock();
-            for (auto& node : state.nodes)
-            {
-                if (node->id == nid && (node->flags & NodeFlags::REGISTERED) != 0)
-                {
-                    node->Send(std::move(msg));
-                    break;
+            if (state.nodeExists(nid)) {
+                if (state.nodes[nid]->flags & NodeFlags::REGISTERED != 0) {
+                    state.nodes[nid]->Send(std::move(msg));
+                } else {
+                    std::cout << "Node with ID " << nid << " is not registered. Send HELLO first." << std::endl;
                 }
+            } else {
+                std::cout << "Node with such ID does not exist" << std::endl;
             }
             state.mtx_nodes.unlock();
         }
         else if (cmd == "list")
         {
             state.mtx_nodes.lock();
-            for (auto& node : state.nodes)
+            for (auto& [node_id, node] : state.nodes)
             {
-                std::cout << "[" << node->id << "] " << inet_ntoa(node->addr.sin_addr)
+                assert(node_id == node->id);
+                std::cout << "[" << node_id << "] " << inet_ntoa(node->addr.sin_addr)
                     << ':' << ntohs(node->addr.sin_port) << " flag<" << node->flags << ">\n";
             }
             state.mtx_nodes.unlock();

--- a/coordinator/src/state.h
+++ b/coordinator/src/state.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <thread>
 #include <memory>
+#include <unordered_map>
 
 #include "node.h"
 
@@ -12,7 +13,8 @@ class State
 private:
     
 public:
-    std::vector<std::shared_ptr<Node>> nodes;
+    
+    std::unordered_map<int, std::shared_ptr<Node>> nodes;
     std::mutex mtx_nodes;
 
     std::vector<std::thread> threads;
@@ -23,5 +25,6 @@ public:
     std::condition_variable cv_recvQueue;
     
     bool shouldQuit = false;
+    bool nodeExists(int node_id) { return nodes.find(node_id) != nodes.end(); }
 };
 


### PR DESCRIPTION
Zmiany po code-review dotyczące koordynatora:

- Dodano return do funkcji main w `coordinator` - #22 
- Zmieniono `std::vector<...> nodes` na `unordered_map` - #23 

Dodatkowo można by się zastanowić w przyszłości nad zrobieniem funkcji `SendMessageToNode`, która patrząc na konkretny wymagany stan Node'a, zwracałaby true / false jeżeli powiodło się wysłanie, ponieważ w funkcji main mamy 3 takie same bloki kodu, różniące się jedynie typem wiadomości. 

- closes #22 
- closes #23 
