### PR TITLE
Add error warnings to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Minimum version of CMake required to build this project
 cmake_minimum_required(VERSION 3.5)
+add_compile_options(-Wall -Wextra -pedantic -Werror)
 
 # Name of the project
 project(BEM)


### PR DESCRIPTION
Patrząc po tym, że na code-review sporo błędów zgłaszał kompilator, można by się zastanowić nad dodaniem takich flag jak `-Wextra` i `-Werror`. 
Ten commit dodaje dodatkowo flagę `-pedantic`, żeby blokować kompilację, natomiast można ją usunąć jeżeli będzie zbyt utrudniać pisanie. 