### PR TITLE
Błedy kompilacji w laboratorium (gcc 7.5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(BEM)
 
 # Set the C++ standard to C++17
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "-pthread")
 
 # Add the "common" directory as a subdirectory
 add_subdirectory(common)

--- a/node/src/execute.cpp
+++ b/node/src/execute.cpp
@@ -8,6 +8,7 @@
 #include <memory> // make_unique
 #include <chrono> // std::chrono::seconds
 #include <iostream>
+#include <sstream>
 
 #define GAME_OUTPUT_BUFFER_SIZE 16
 


### PR DESCRIPTION
- narzekało na "incomplete type" dla `std::stringstream` w execute.cpp:140, dodano header
- narzekało na brak referencji do `pthread_create` -> dodano flagę w CMakeLists.txt
---
Dodatkowo: GCC 7.5 nie obsługuje std::filesystem, można skorzystać z std::experimental::filesystem, ale prawdopodobnie trzeba by dodać kolejne flagi 