### PR TITLE
Błędy po oddaniu projektu

### DIFF
--- a/coordinator/src/main.cpp
+++ b/coordinator/src/main.cpp
@@ -20,6 +20,7 @@
 #include "json.hpp"
 #include "config.h"
 #include "commands.h"
+#include "signal.h"
 
 
 bool setup(State& state, const std::string& configpath) {
@@ -27,6 +28,7 @@ bool setup(State& state, const std::string& configpath) {
 }
 
 int main (int argc, char* argv[]) {
+    signal(SIGPIPE, SIG_IGN);
     std::string configpath = std::string(DEFAULT_CONFIG_FILENAME);
     if (argc == 2) {
         configpath = std::string(argv[1]);

--- a/coordinator/src/readNode.cpp
+++ b/coordinator/src/readNode.cpp
@@ -15,7 +15,7 @@ void readNode(int sock, std::shared_ptr<Node> node, State& state)
     while (!state.shouldQuit)
     {
         auto len = read(sock, &buf, 32);
-	    if (len == -1) 
+	    if (len <= 0) 
         {
             // error(1, errno, "read failed on node %d", node->id);
             state.terminateNode(node->id);
@@ -33,10 +33,6 @@ void readNode(int sock, std::shared_ptr<Node> node, State& state)
             }
 
             factory.FinishExtraction();
-        }
-        else
-        {
-            break;
         }
     }
 }

--- a/coordinator/src/readNode.cpp
+++ b/coordinator/src/readNode.cpp
@@ -17,10 +17,11 @@ void readNode(int sock, std::shared_ptr<Node> node, State& state)
         auto len = read(sock, &buf, 32);
 	    if (len == -1) 
         {
-            error(1, errno, "read failed on node %d", node->id);
+            // error(1, errno, "read failed on node %d", node->id);
+            state.terminateNode(node->id);
+            break;
         }
-
-        if (len > 0)
+        else if (len > 0)
         {
             factory.Fill(buf, len);
             for (auto& msg : factory.readyMessages)
@@ -32,6 +33,10 @@ void readNode(int sock, std::shared_ptr<Node> node, State& state)
             }
 
             factory.FinishExtraction();
+        }
+        else
+        {
+            break;
         }
     }
 }

--- a/coordinator/src/state.h
+++ b/coordinator/src/state.h
@@ -51,7 +51,7 @@ struct State
 
         // TODO: add gracefuly killing threads, destroying resources
         // TODO: WR or RDWR? Maybe node can send result? 
-        shutdown(nodes[nid]->socket, SHUT_WR);
+        shutdown(nodes[nid]->socket, SHUT_RDWR);
         nodes.erase(nid);
 
         mtx_nodes.unlock();

--- a/coordinator/src/writeNode.cpp
+++ b/coordinator/src/writeNode.cpp
@@ -22,9 +22,10 @@ void writeNode(int sock, std::shared_ptr<Node> node, State& state)
         while (mbuf.RemainingBytes() > 0)
         {
             auto ret = write(sock, mbuf.Next(), mbuf.RemainingBytes());
-            if  (ret == -1)
+            if  (ret <= 0)
             {
-                error(1, errno, "write failed on node %d", node->id);
+                state.terminateNode(node->id);
+                break;
             }
 
             mbuf.Advance(ret);

--- a/node/src/communication.cpp
+++ b/node/src/communication.cpp
@@ -59,7 +59,7 @@ void read_from_server_in_loop(int socket, size_t read_size) {
 
         auto len = read(socket, &buffer, read_size);
 	    if (len == -1) {
-            error(1, errno, "read failed on server");
+            std::cerr << "read(): Read Failed on server" << std::endl;
             break;
         } 
         else if (len > 0) {
@@ -101,8 +101,7 @@ void write_to_server_in_loop(int socket) {
         auto ret = write(socket, mbuf.Next(), mbuf.RemainingBytes());
 
         if  (ret == -1) { 
-            // TODO: should we interpret other codes? like EAGAIN
-            error(1, errno, "write failed");
+            std::cerr << "write(): Wead failed on server" << std::endl;
             break;
         } else if (ret == 0) {
             // connection was closed

--- a/node/src/graceful.cpp
+++ b/node/src/graceful.cpp
@@ -23,7 +23,7 @@ void terminate_program() {
 
         // read_from_server_in_loop, write_to_server_in_loop
         // TODO: SHUT_RW or SHUT_RWRD?
-        shutdown(getGlobalState().socket, SHUT_RD);
+        shutdown(getGlobalState().socket, SHUT_RDWR);
     }
     getGlobalState().mtx_terminate.unlock();
 }


### PR DESCRIPTION
- Wciąga do koordynatora taką obsługę błędów jak jest na nodzie (tj. break z pętli etc)
- `terminateNode` zamiast `error()`
- Chyba jest dobrze teraz? Mi `ss` na pi nie wyznaje przemocy i nie chce killować tych socketów, ale zakładam że nie wywali się teraz i tak
- Weź to przetestuj tylko mordo i gitara siema


_In sorrow we must go, but not in despair. Behold! We are not bound for ever to the circles of the world, and beyond them is more than memory. Farewell!_